### PR TITLE
Feat / create cd with github action

### DIFF
--- a/.github/workflows/snugg_CD.yml
+++ b/.github/workflows/snugg_CD.yml
@@ -1,0 +1,20 @@
+name: Django CD
+on:
+  push:
+    branches: [ develop ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Run deploy scripts on server
+      uses: appleboy/ssh-action@master
+      with:
+        key: ${{ secrets.SSH_KEY }}
+        host: ${{ secrets.SSH_HOST }}
+        username: ${{ screts.SSH_USER }}
+        script: |
+          sh deploy


### PR DESCRIPTION
develop branch에 새로운 PR이 push가 될 시 ssh에 접속해서 @askrid 님이 작성해주신 deploy script를 실행하는 코드를 작성했습니다.
굉장히 간단한 코드라 설명할 게 별로 없습니다만, 동작 원리는 ssh에 접속한 후, 미리 만들어놓은 deploy 스크립트의 심볼릭 링크인 deploy 파일을 실행하는 코드입니다. 사실 그냥 snugg-server 폴더로 이동해서 deploy.sh 를 실행해도 되는데 접속하자마자 deploy를 할 수 있으면 편할 것 같아서 링크를 만들어두었습니다.
이게 작동이 잘 되는지 미리 확인해볼 길이 없어서... 혹시 작동이 잘 안 되면 추후에 리팩토링하겠습니다