### PR TITLE
fix: call user manager's create_user() on user creation

### DIFF
--- a/snugg/apps/user/serializers.py
+++ b/snugg/apps/user/serializers.py
@@ -17,7 +17,7 @@ class SignupService(serializers.ModelSerializer):
         extra_kwargs = {"password": {"write_only": True}}
 
     def create(self, validated_data):
-        user = super().create(validated_data)
+        user = User.objects.create_user(**validated_data)
         user_data = UserSerializer(user).data
 
         return user_data, jwt_token_of(user)


### PR DESCRIPTION
`SignupService` 작성하는 과정에서 `create_user()`를 호출하지 않아, 유저가 회원가입을 할 때 비밀번호가 해싱되지 않는 버그가 있었습니다.