### PR TITLE
Refact/field admin

### DIFF
--- a/snugg/apps/qna/admin.py
+++ b/snugg/apps/qna/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
+from django.urls import reverse
 from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 from mptt.admin import DraggableMPTTAdmin
 
 from .models import Answer, Comment, Field, Post
@@ -23,8 +25,29 @@ class FieldAdmin(DraggableMPTTAdmin):
         )
 
 
+class PostAdmin(admin.ModelAdmin):
+    list_display = ("pk", "title", "writer_link")
+
+    list_display_links = (
+        "pk",
+        "title",
+    )
+
+    # readonly_fields = ('user_link',)
+
+    def writer_link(self, obj):
+        return mark_safe(
+            '<a href="{}">{}</a>'.format(
+                reverse("admin:user_user_change", args=(obj.writer.pk,)),
+                obj.writer.email,
+            )
+        )
+
+    writer_link.short_description = "writer"
+
+
 # Register your models here.
 admin.site.register(Answer)
 admin.site.register(Comment)
 admin.site.register(Field, FieldAdmin)
-admin.site.register(Post)
+admin.site.register(Post, PostAdmin)

--- a/snugg/apps/qna/admin.py
+++ b/snugg/apps/qna/admin.py
@@ -33,7 +33,7 @@ class PostAdmin(admin.ModelAdmin):
         "title",
     )
 
-    # readonly_fields = ('user_link',)
+    readonly_fields = ("writer_link",)
 
     def writer_link(self, obj):
         return mark_safe(

--- a/snugg/apps/qna/admin.py
+++ b/snugg/apps/qna/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.utils.html import format_html
 from mptt.admin import DraggableMPTTAdmin
 
 from .models import Answer, Comment, Field, Post
@@ -9,6 +10,17 @@ class FieldAdmin(DraggableMPTTAdmin):
         "tree_actions",
         "indented_title",
     )
+
+    list_display_links = ("indented_title",)
+
+    mptt_level_indent = 20
+
+    def indented_title(self, instance):
+        return format_html(
+            '<div style="text-indent:{}px">{}</div>',
+            instance._mpttfield("level") * self.mptt_level_indent,
+            instance.name,  # Or whatever you want to put here
+        )
 
 
 # Register your models here.

--- a/snugg/apps/qna/models.py
+++ b/snugg/apps/qna/models.py
@@ -16,6 +16,9 @@ class Field(MPTTModel):
         "self", on_delete=models.CASCADE, null=True, blank=True, related_name="children"
     )
 
+    def __str__(self):
+        return self.name
+
 
 class Answer(models.Model):
     post = models.ForeignKey("Post", null=True, on_delete=models.CASCADE)


### PR DESCRIPTION
Admin 페이지에서 Qna-Field와 Qna-Post 에서 각 오브젝트들이 pk로만 보이기 때문에 구별하기 어려워서 개선작업을 진행했습니다.
Field 변경 전
<img width="227" alt="image" src="https://user-images.githubusercontent.com/71511067/162566153-0c1db483-4029-45c2-9e4f-cf2963e73300.png">
Field 변경 후
<img width="223" alt="image" src="https://user-images.githubusercontent.com/71511067/162566161-ad910e4e-4acb-41eb-b365-fdc4d4805431.png">

Post 변경 전
<img width="179" alt="image" src="https://user-images.githubusercontent.com/71511067/162566175-23b41646-6ec2-4a74-a7f5-ef43936721ee.png">
Post 변경 후
<img width="691" alt="image" src="https://user-images.githubusercontent.com/71511067/162566182-a50ee03b-51f9-4360-98bd-dd23e94deef0.png">
