### PR TITLE
Feat/refresh token

### DIFF
--- a/snugg/apps/user/schemas.py
+++ b/snugg/apps/user/schemas.py
@@ -4,10 +4,16 @@ from rest_framework import serializers
 from .examples import TestUser
 from .serializers import UserSerializer
 
-
-class Token(serializers.Serializer):
+class RefreshToken(serializers.Serializer):
     refresh = serializers.CharField()
+
+
+class AccessToekn(serializers.Serializer):
     access = serializers.CharField()
+
+
+class Token(AccessToekn, RefreshToken):
+    pass
 
 
 class UserToken(serializers.Serializer):
@@ -52,4 +58,12 @@ auth_viewset_schema = extend_schema_view(
             ),
         },
     ),
+    refresh=extend_schema(
+        summary="Refresh Token",
+        description="Renew refresh token and get new accesss token",
+        responses={
+            200: OpenApiResponse(response=RefreshToken),
+            400: OpenApiResponse(description="Incorrect or missing refresh token.")
+        }
+    )
 )

--- a/snugg/apps/user/serializers.py
+++ b/snugg/apps/user/serializers.py
@@ -49,9 +49,9 @@ class SigninService(serializers.Serializer):
 
 
 class SignoutService(serializers.Serializer):
-    refresh_token = serializers.CharField()
+    refresh = serializers.CharField()
 
-    def validate_refresh_token(self, value):
+    def validate_refresh(self, value):
         try:
             RefreshToken(value)
         except TokenError:
@@ -61,7 +61,7 @@ class SignoutService(serializers.Serializer):
 
     @transaction.atomic
     def execute(self):
-        refresh_token = RefreshToken(self.validated_data.get("refresh_token"))
+        refresh_token = RefreshToken(self.validated_data.get("refresh"))
         refresh_token.blacklist()
 
         request = self.context.get("request")
@@ -71,7 +71,7 @@ class SignoutService(serializers.Serializer):
         return True
 
 
-class RefreshService(TokenRefreshSerializer):
+class RefreshService(SignoutService, TokenRefreshSerializer):
     token_class = RefreshToken
 
     def execute(self):

--- a/snugg/apps/user/serializers.py
+++ b/snugg/apps/user/serializers.py
@@ -69,6 +69,15 @@ class SignoutService(serializers.Serializer):
         return True
 
 
+class RefreshService(SignoutService):
+    def execute(self):
+        super().execute()
+        user = self.context.get("user")
+        user_data = UserSerializer(user).data
+
+        return user_data, jwt_token_of(user)
+
+
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User

--- a/snugg/apps/user/serializers.py
+++ b/snugg/apps/user/serializers.py
@@ -1,8 +1,10 @@
+from tokenize import Token
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import update_last_login
 from django.db import transaction
 from rest_framework import serializers
 from rest_framework.exceptions import AuthenticationFailed
+from rest_framework_simplejwt.serializers import TokenRefreshSerializer
 from rest_framework_simplejwt.exceptions import TokenError
 
 from snugg.tokens import AccessToken, RefreshToken, jwt_token_of
@@ -69,13 +71,13 @@ class SignoutService(serializers.Serializer):
         return True
 
 
-class RefreshService(SignoutService):
-    def execute(self):
-        super().execute()
-        user = self.context.get("user")
-        user_data = UserSerializer(user).data
+class RefreshService(TokenRefreshSerializer):
+    token_class = RefreshToken
 
-        return user_data, jwt_token_of(user)
+    def execute(self):
+        return {
+            "access": self.validated_data.get("access")
+        }
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/snugg/apps/user/tests.py
+++ b/snugg/apps/user/tests.py
@@ -163,7 +163,7 @@ class SignoutTests(AuthAPITestCase):
         cls.user = UserFactory()
 
         cls.token = jwt_token_of(cls.user)
-        cls.data = {"refresh_token": cls.token.get("refresh")}
+        cls.data = {"refresh": cls.token.get("refresh")}
 
     def setUp(self):
         self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {self.token.get('access')}")
@@ -179,20 +179,20 @@ class SignoutTests(AuthAPITestCase):
 
     def test_signout_refresh_token_wrong(self):
         data = self.data.copy()
-        data.update({"refresh_token": fake.password()})
+        data.update({"refresh": fake.password()})
         response = self.signout(data)
 
         self.assertContains(
-            response, "refresh_token", None, status.HTTP_400_BAD_REQUEST
+            response, "refresh", None, status.HTTP_400_BAD_REQUEST
         )
 
     def test_signout_refresh_token_missing(self):
         data = self.data.copy()
-        data["refresh_token"] = ""
+        data["refresh"] = ""
         response = self.signout(data)
 
         self.assertContains(
-            response, "refresh_token", None, status.HTTP_400_BAD_REQUEST
+            response, "refresh", None, status.HTTP_400_BAD_REQUEST
         )
 
     def test_signout_access_token_missing(self):

--- a/snugg/apps/user/views.py
+++ b/snugg/apps/user/views.py
@@ -52,15 +52,15 @@ class AuthViewSet(GenericViewSet):
     @action(
         detail=False,
         methods=["POST"],
-        permissions_classes=(permissions.AllowAny, ),
+        permission_classes=(permissions.AllowAny, ),
         serializer_class=RefreshService,
     )
     def refresh(self, request):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        user_data, jwt_token = serializer.execute()
+        jwt_token = serializer.execute()
 
-        return Response({"user": user_data, "token": jwt_token})
+        return Response({"token": jwt_token})
 
 
     # TODO: Implement "deactivate" along with PUT /users/{pk}

--- a/snugg/apps/user/views.py
+++ b/snugg/apps/user/views.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from .schemas import auth_viewset_schema
-from .serializers import SigninService, SignoutService, SignupService
+from .serializers import SigninService, SignoutService, SignupService, RefreshService
 
 
 @auth_viewset_schema
@@ -48,6 +48,20 @@ class AuthViewSet(GenericViewSet):
         success = serializer.execute()
 
         return Response({"success": bool(success)})
+    
+    @action(
+        detail=False,
+        methods=["POST"],
+        permissions_classes=(permissions.AllowAny, ),
+        serializer_class=RefreshService,
+    )
+    def refresh(self, request):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        user_data, jwt_token = serializer.execute()
+
+        return Response({"user": user_data, "token": jwt_token})
+
 
     # TODO: Implement "deactivate" along with PUT /users/{pk}
     # @action(


### PR DESCRIPTION
# Refresh Token API
refresh token을 request body로 넣으면 refresh token의 만료시간이 갱신되고 새로운 access token을 반환합니다.
일관성을 위해서 SigninService와 유사하게 response body를 만들고 싶었는데 access token이 만료되지 않았다는 보장이 없어서 user객체를 얻을 방법을 모르겠네요. 그래서 일단은 새로운 access token 만 제공해줍니다.

URL : `~/auth/refresh/`
