### PR TITLE
Refact/answer list

### DIFF
--- a/snugg/apps/qna/models.py
+++ b/snugg/apps/qna/models.py
@@ -49,7 +49,7 @@ class Post(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
     accepted_answer = models.OneToOneField(
-        "Answer", null=True, on_delete=models.CASCADE, related_name="bulletin"
+        "Answer", null=True, on_delete=models.SET_NULL, related_name="bulletin"
     )
     comments = GenericRelation("Comment", related_query_name="post")
     tags = TaggableManager()

--- a/snugg/apps/qna/models.py
+++ b/snugg/apps/qna/models.py
@@ -1,6 +1,5 @@
 from django.contrib.auth import get_user_model
-from django.contrib.contenttypes.fields import (GenericForeignKey,
-                                                GenericRelation)
+from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from mptt.fields import TreeForeignKey

--- a/snugg/apps/qna/schemas.py
+++ b/snugg/apps/qna/schemas.py
@@ -1,5 +1,4 @@
-from drf_spectacular.utils import (OpenApiResponse, extend_schema,
-                                   extend_schema_view)
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 
 from .serializers import PostSerializer
 

--- a/snugg/apps/qna/serializers.py
+++ b/snugg/apps/qna/serializers.py
@@ -50,6 +50,9 @@ class PostSerializer(TaggitSerializer, serializers.ModelSerializer):
 
             if value.post != self.instance:
                 raise serializers.ValidationError("이 질문에 달린 답변만 채택할 수 있습니다.")
+            
+            if value.writer == self.context.get("request").user:
+                raise serializers.ValidationError("자신의 답변은 채택할 수 없습니다.")
 
         return value
 
@@ -81,9 +84,6 @@ class AnswerSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("이미 답변이 채택된 질문입니다.")
 
         user = self.context.get("request").user
-
-        if post.writer == user:
-            raise serializers.ValidationError("본인의 질문에는 답변을 달 수 없습니다.")
 
         if post.answer_set.filter(writer=user).exists():
             raise serializers.ValidationError("이미 답변을 단 질문입니다.")

--- a/snugg/apps/qna/serializers.py
+++ b/snugg/apps/qna/serializers.py
@@ -50,7 +50,7 @@ class PostSerializer(TaggitSerializer, serializers.ModelSerializer):
 
             if value.post != self.instance:
                 raise serializers.ValidationError("이 질문에 달린 답변만 채택할 수 있습니다.")
-            
+
             if value.writer == self.context.get("request").user:
                 raise serializers.ValidationError("자신의 답변은 채택할 수 없습니다.")
 

--- a/snugg/apps/qna/tests_answer.py
+++ b/snugg/apps/qna/tests_answer.py
@@ -7,8 +7,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from .models import Answer, Post
-from .tests import (FieldFactory, PostAPITestCase, PostFactory, UserFactory,
-                    fake)
+from .tests import FieldFactory, PostAPITestCase, PostFactory, UserFactory, fake
 
 
 class AnswerFactory(DjangoModelFactory):
@@ -63,7 +62,7 @@ class AnswerCreateTests(AnswerAPITestCase):
         )
 
         self.client.force_authenticate(user=self.user)
-        
+
         self.post = Post.objects.first()
 
         self.data = {

--- a/snugg/apps/qna/views.py
+++ b/snugg/apps/qna/views.py
@@ -96,6 +96,7 @@ class AnswerViewSet(ModelViewSet):
         "created_at",
         "updated_at",
     )
+    filterset_fields = ["post"]
     ordering = "-created_at"
     pagination_class = PostPagination
 

--- a/snugg/apps/qna/views.py
+++ b/snugg/apps/qna/views.py
@@ -4,10 +4,10 @@ from rest_framework.pagination import CursorPagination
 from rest_framework.viewsets import GenericViewSet, ModelViewSet
 
 from ...s3 import create_presigned_post, delete_object
+from ...settings import MEDIA_ROOT
 from .models import Answer, Post
 from .schemas import post_viewset_schema
 from .serializers import AnswerSerializer, PostSerializer
-from ...settings import MEDIA_ROOT
 
 
 class PostFilter(filters.FilterSet):
@@ -52,7 +52,7 @@ class PostViewSet(ModelViewSet):
             "url": "https://snugg-s3.s3.amazonaws.com/",
             "fields": {
                 "key": path,
-            }
+            },
         }
         return response
 
@@ -106,10 +106,9 @@ class AnswerViewSet(ModelViewSet):
             "url": "https://snugg-s3.s3.amazonaws.com/",
             "fields": {
                 "key": path,
-            }
+            },
         }
         return response
-
 
     def create(self, request, *args, **kwargs):
         response = super().create(request, *args, **kwargs)

--- a/snugg/apps/user/models.py
+++ b/snugg/apps/user/models.py
@@ -1,5 +1,8 @@
-from django.contrib.auth.models import (AbstractBaseUser, BaseUserManager,
-                                        PermissionsMixin)
+from django.contrib.auth.models import (
+    AbstractBaseUser,
+    BaseUserManager,
+    PermissionsMixin,
+)
 from django.db import models
 
 

--- a/snugg/apps/user/schemas.py
+++ b/snugg/apps/user/schemas.py
@@ -1,9 +1,9 @@
-from drf_spectacular.utils import (OpenApiResponse, extend_schema,
-                                   extend_schema_view)
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import serializers
 
 from .examples import TestUser
 from .serializers import UserSerializer
+
 
 class RefreshToken(serializers.Serializer):
     refresh = serializers.CharField()
@@ -64,7 +64,7 @@ auth_viewset_schema = extend_schema_view(
         description="Renew refresh token and get new accesss token",
         responses={
             200: OpenApiResponse(response=RefreshToken),
-            400: OpenApiResponse(description="Incorrect or missing refresh token.")
-        }
-    )
+            400: OpenApiResponse(description="Incorrect or missing refresh token."),
+        },
+    ),
 )

--- a/snugg/apps/user/serializers.py
+++ b/snugg/apps/user/serializers.py
@@ -1,11 +1,12 @@
 from tokenize import Token
+
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import update_last_login
 from django.db import transaction
 from rest_framework import serializers
 from rest_framework.exceptions import AuthenticationFailed
-from rest_framework_simplejwt.serializers import TokenRefreshSerializer
 from rest_framework_simplejwt.exceptions import TokenError
+from rest_framework_simplejwt.serializers import TokenRefreshSerializer
 
 from snugg.tokens import AccessToken, RefreshToken, jwt_token_of
 
@@ -75,9 +76,7 @@ class RefreshService(SignoutService, TokenRefreshSerializer):
     token_class = RefreshToken
 
     def execute(self):
-        return {
-            "access": self.validated_data.get("access")
-        }
+        return {"access": self.validated_data.get("access")}
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/snugg/apps/user/tests.py
+++ b/snugg/apps/user/tests.py
@@ -182,18 +182,14 @@ class SignoutTests(AuthAPITestCase):
         data.update({"refresh": fake.password()})
         response = self.signout(data)
 
-        self.assertContains(
-            response, "refresh", None, status.HTTP_400_BAD_REQUEST
-        )
+        self.assertContains(response, "refresh", None, status.HTTP_400_BAD_REQUEST)
 
     def test_signout_refresh_token_missing(self):
         data = self.data.copy()
         data["refresh"] = ""
         response = self.signout(data)
 
-        self.assertContains(
-            response, "refresh", None, status.HTTP_400_BAD_REQUEST
-        )
+        self.assertContains(response, "refresh", None, status.HTTP_400_BAD_REQUEST)
 
     def test_signout_access_token_missing(self):
         self.client.credentials()

--- a/snugg/apps/user/views.py
+++ b/snugg/apps/user/views.py
@@ -4,7 +4,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from .schemas import auth_viewset_schema
-from .serializers import SigninService, SignoutService, SignupService, RefreshService
+from .serializers import RefreshService, SigninService, SignoutService, SignupService
 
 
 @auth_viewset_schema
@@ -48,11 +48,11 @@ class AuthViewSet(GenericViewSet):
         success = serializer.execute()
 
         return Response({"success": bool(success)})
-    
+
     @action(
         detail=False,
         methods=["POST"],
-        permission_classes=(permissions.AllowAny, ),
+        permission_classes=(permissions.AllowAny,),
         serializer_class=RefreshService,
     )
     def refresh(self, request):
@@ -61,7 +61,6 @@ class AuthViewSet(GenericViewSet):
         jwt_token = serializer.execute()
 
         return Response({"token": jwt_token})
-
 
     # TODO: Implement "deactivate" along with PUT /users/{pk}
     # @action(

--- a/snugg/tokens.py
+++ b/snugg/tokens.py
@@ -1,5 +1,4 @@
-from rest_framework_simplejwt.tokens import (AccessToken, BlacklistMixin,
-                                             RefreshToken)
+from rest_framework_simplejwt.tokens import AccessToken, BlacklistMixin, RefreshToken
 
 
 class RefreshToken(RefreshToken):

--- a/snugg/urls.py
+++ b/snugg/urls.py
@@ -16,9 +16,11 @@ Including another URLconf
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
-from drf_spectacular.views import (SpectacularJSONAPIView,
-                                   SpectacularRedocView,
-                                   SpectacularSwaggerView)
+from drf_spectacular.views import (
+    SpectacularJSONAPIView,
+    SpectacularRedocView,
+    SpectacularSwaggerView,
+)
 
 urlpatterns = [
     path("admin/", admin.site.urls),


### PR DESCRIPTION
1. AnswerViewSet에서 쿼리파람을 통해 특정 질문에 달린 답변들의 리스트를 받아올 수 있도록 했습니다.
2. 이전 회의에서 논의된 내용을 바탕으로 답변의 수정 및 삭제에 대한 validation을 수정하였습니다.
3. accepted_answer의 on_delete 옵션을 수정하였습니다. 왜냐하면 on_delete=models.CASCADE로 되어있으면 채택된 질문을 삭제할 때 질문도 삭제되기 때문입니다.