### PR TITLE
fix: add apigateway url to csrf_trusted_origins

### DIFF
--- a/snugg/settings.py
+++ b/snugg/settings.py
@@ -235,3 +235,5 @@ SPECTACULAR_SETTINGS = {
 # taggit settings
 
 TAGGIT_CASE_INSENSITIVE = True
+
+CSRF_TRUSTED_ORIGINS = ["https://fp026w45m5.execute-api.ap-northeast-2.amazonaws.com"]


### PR DESCRIPTION
api gateway로는 admin사이트에서 로그인이 안 되는 문제는 csrf_trusted_origins에 api gateway 주소를 추가하니까 해결되었습니다.